### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Stories in Ready](https://badge.waffle.io/daniel-gallagher/graylog-addons.png?label=ready&title=Ready)](https://waffle.io/daniel-gallagher/graylog-addons)
 # graylog-addons
 Custom Graylog extractors, content packs, and other stuff


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/daniel-gallagher/graylog-addons

This was requested by a real person (user daniel-gallagher) on waffle.io, we're not trying to spam you.